### PR TITLE
Add attribute and key name to resultName generated by ExpressionLanguageEngine

### DIFF
--- a/src/main/java/org/jmxtrans/agent/JConsoleNameStrategyImpl.java
+++ b/src/main/java/org/jmxtrans/agent/JConsoleNameStrategyImpl.java
@@ -30,7 +30,6 @@ import javax.management.ObjectName;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Builds names with general rules like JConsole / VisualVM do.
@@ -41,11 +40,16 @@ import java.util.Map;
  *
  * @author <a href="mailto:maheshkelkar@gmail.com">Mahesh V Kelkar</a>
  */
-public class JConsoleNameStrategyImpl implements ResultNameStrategy {
+public class JConsoleNameStrategyImpl extends ResultNameStrategyImpl {
 
-    @Nonnull
+    /**
+     * Transforms an {@linkplain javax.management.ObjectName} into a plain {@linkplain String}
+     * only composed of ('a' to 'Z', 'A' to 'Z', '.', '_') similar to JConsole naming
+     *
+     * '_' is the escape char for not compliant chars.
+     */
     @Override
-    public String getResultName(Query query, ObjectName objectName, String key, String attributeName) {
+    protected String escapeObjectName(@Nonnull ObjectName objectName) {
 
         /** Add objectName's domain */
         StringBuilder result = new StringBuilder();
@@ -61,22 +65,7 @@ public class JConsoleNameStrategyImpl implements ResultNameStrategy {
                     result);
         }
 
-        /** Add attribute name */
-        if (attributeName != null && !attributeName.isEmpty()) {
-            result.append('.');
-            StringUtils2.appendEscapedNonAlphaNumericChars(attributeName, false, result);
-        }
-
-        /** Add composite-data key, if present */
-        if (key != null && !key.isEmpty()){
-            result.append('.');
-            StringUtils2.appendEscapedNonAlphaNumericChars(key, false, result);
-        }
-
         return result.toString();
     }
 
-    @Override
-    public void postConstruct(Map<String, String> settings) {
-    }
 }

--- a/src/main/java/org/jmxtrans/agent/JConsoleNameStrategyImpl.java
+++ b/src/main/java/org/jmxtrans/agent/JConsoleNameStrategyImpl.java
@@ -49,7 +49,7 @@ public class JConsoleNameStrategyImpl implements ResultNameStrategy {
 
         /** Add objectName's domain */
         StringBuilder result = new StringBuilder();
-        StringUtils2.appendEscapedNonAlphaNumericChars(objectName.getDomain(), result);
+        StringUtils2.appendEscapedNonAlphaNumericChars(objectName.getDomain(), false, result);
 
         /** Walk through (sorted) properties of the ObjectName and add values to the result */
         List<String> keys = Collections.list(objectName.getKeyPropertyList().keys());

--- a/src/main/java/org/jmxtrans/agent/JConsoleNameStrategyImpl.java
+++ b/src/main/java/org/jmxtrans/agent/JConsoleNameStrategyImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2015 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import org.jmxtrans.agent.util.StringUtils2;
+
+import javax.annotation.Nonnull;
+import javax.management.ObjectName;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds names with general rules like JConsole / VisualVM do.
+ * i.e. <domain-name>.<property-name><property-name><attribute-name><composite-data-key-name>
+ *
+ * E.g. For objectName = "type:name=metric,value=bar" and attribute "count",
+ *      it will general resultName = "type.metric.bar.count"
+ *
+ * @author <a href="mailto:maheshkelkar@gmail.com">Mahesh V Kelkar</a>
+ */
+public class JConsoleNameStrategyImpl implements ResultNameStrategy {
+
+    @Nonnull
+    @Override
+    public String getResultName(Query query, ObjectName objectName, String key, String attributeName) {
+
+        /** Add objectName's domain */
+        StringBuilder result = new StringBuilder();
+        StringUtils2.appendEscapedNonAlphaNumericChars(objectName.getDomain(), result);
+
+        /** Walk through (sorted) properties of the ObjectName and add values to the result */
+        List<String> keys = Collections.list(objectName.getKeyPropertyList().keys());
+        Collections.sort(keys);
+        for (Iterator<String> it = keys.iterator(); it.hasNext(); ) {
+            String propertyKey = it.next();
+            result.append('.');
+            StringUtils2.appendEscapedNonAlphaNumericChars(objectName.getKeyProperty(propertyKey), false,
+                    result);
+        }
+
+        /** Add attribute name */
+        if (attributeName != null && !attributeName.isEmpty()) {
+            result.append('.');
+            StringUtils2.appendEscapedNonAlphaNumericChars(attributeName, false, result);
+        }
+
+        /** Add composite-data key, if present */
+        if (key != null && !key.isEmpty()){
+            result.append('.');
+            StringUtils2.appendEscapedNonAlphaNumericChars(key, false, result);
+        }
+
+        return result.toString();
+    }
+
+    @Override
+    public void postConstruct(Map<String, String> settings) {
+    }
+}

--- a/src/main/java/org/jmxtrans/agent/JmxTransExporterBuilder.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporterBuilder.java
@@ -122,7 +122,8 @@ public class JmxTransExporterBuilder {
             String objectName = queryElement.getAttribute("objectName");
             String attribute = queryElement.getAttribute("attribute");
             String key = queryElement.hasAttribute("key") ? queryElement.getAttribute("key") : null;
-            String resultAlias = queryElement.getAttribute("resultAlias");
+            String resultAlias = queryElement.hasAttribute("resultAlias") ?
+                    queryElement.getAttribute("resultAlias") : null;
             String type = queryElement.getAttribute("type");
             Integer position;
             try {

--- a/src/main/java/org/jmxtrans/agent/Query.java
+++ b/src/main/java/org/jmxtrans/agent/Query.java
@@ -151,7 +151,7 @@ public class Query {
             try {
                 attributeValue = mbeanServer.getAttribute(objectName, attribute);
             } catch (Exception ex) {
-                logger.warning("Failed to fetch attribute for '" + objectName + "'#" + attribute + ", exception: " + ex.getMessage());
+                logger.info("Failed to fetch attribute for '" + objectName + "'#" + attribute + ", exception: " + ex.getMessage());
                 return;
             }
 

--- a/src/main/java/org/jmxtrans/agent/Query.java
+++ b/src/main/java/org/jmxtrans/agent/Query.java
@@ -151,7 +151,7 @@ public class Query {
             try {
                 attributeValue = mbeanServer.getAttribute(objectName, attribute);
             } catch (Exception ex) {
-                logger.info("Failed to fetch attribute for '" + objectName + "'#" + attribute + ", exception: " + ex.getMessage());
+                logger.warning("Failed to fetch attribute for '" + objectName + "'#" + attribute + ", exception: " + ex.getMessage());
                 return;
             }
 

--- a/src/main/java/org/jmxtrans/agent/ResultNameStrategyImpl.java
+++ b/src/main/java/org/jmxtrans/agent/ResultNameStrategyImpl.java
@@ -105,12 +105,10 @@ public class ResultNameStrategyImpl implements ResultNameStrategy {
     public String getResultName(@Nonnull Query query, @Nonnull ObjectName objectName, @Nullable String key, @Nonnull String attribute) {
         String result;
         if (query.getResultAlias() == null) {
-            result = escapeObjectName(objectName);
-            if (attribute != null && !attribute.isEmpty()) {
-                result += "." + attribute;
-            }
-            if (key != null && !key.isEmpty()) {
-                result += "." + key;
+            if (key == null) {
+                result = escapeObjectName(objectName) + "." + attribute;
+            } else {
+                result = escapeObjectName(objectName) + "." + attribute + "." + key;
             }
         } else {
             result = expressionLanguageEngine.resolveExpression(query.getResultAlias(), objectName);

--- a/src/main/java/org/jmxtrans/agent/ResultNameStrategyImpl.java
+++ b/src/main/java/org/jmxtrans/agent/ResultNameStrategyImpl.java
@@ -105,10 +105,12 @@ public class ResultNameStrategyImpl implements ResultNameStrategy {
     public String getResultName(@Nonnull Query query, @Nonnull ObjectName objectName, @Nullable String key, @Nonnull String attribute) {
         String result;
         if (query.getResultAlias() == null) {
-            if(key == null) {
-                result = escapeObjectName(objectName) + "." + attribute;
-            } else {
-                result = escapeObjectName(objectName) + "." + attribute + "." + key;
+            result = escapeObjectName(objectName);
+            if (attribute != null && !attribute.isEmpty()) {
+                result += "." + attribute;
+            }
+            if (key != null && !key.isEmpty()) {
+                result += "." + key;
             }
         } else {
             result = expressionLanguageEngine.resolveExpression(query.getResultAlias(), objectName);

--- a/src/test/java/org/jmxtrans/agent/JConsoleNameStrategyImplTest.java
+++ b/src/test/java/org/jmxtrans/agent/JConsoleNameStrategyImplTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+package org.jmxtrans.agent;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.management.ObjectName;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author <a href="mailto:maheshkelkar@gmail.com">Mahesh V Kelkar</a>
+ */
+public class JConsoleNameStrategyImplTest {
+
+    static JConsoleNameStrategyImpl strategy = new JConsoleNameStrategyImpl();
+    static Query query = new Query("*:*", "count", strategy); /* dummy */
+
+    @Test
+    public void testGetResultName() throws Exception {
+        String objectName = "Catalina:type=Resource,resourcetype=Context,host=localhost,class=javax.sql.DataSource,name=\"jdbc/my-datasource\"";
+        String actual = strategy.getResultName(query, new ObjectName(objectName), "usage", "count");
+        assertThat(actual, is("Catalina.javax.sql.DataSource.localhost.jdbc_my-datasource.Context.Resource.count.usage"));
+    }
+
+    @Test
+    public void testGetResultNameWithObjectName() throws Exception {
+        String objectName = "Catalina:type=Resource,resourcetype=Context,host=localhost,class=javax.sql.DataSource,name=\"jdbc/my-datasource\"";
+        String actual = strategy.getResultName(query, new ObjectName(objectName), null, null);
+        assertThat(actual, is("Catalina.javax.sql.DataSource.localhost.jdbc_my-datasource.Context.Resource"));
+    }
+
+    @Test
+    public void testGetResultNameWithNullAttributeName() throws Exception {
+        String objectName = "Catalina:type=Resource,resourcetype=Context,host=localhost,class=javax.sql.DataSource,name=\"jdbc/my-datasource\"";
+        String actual = strategy.getResultName(query, new ObjectName(objectName), "usage", null);
+        assertThat(actual, is("Catalina.javax.sql.DataSource.localhost.jdbc_my-datasource.Context.Resource.usage"));
+    }
+
+    @Test
+    public void testGetResultNameWithNullKeyName() throws Exception {
+        String objectName = "Catalina:type=Resource,resourcetype=Context,host=localhost,class=javax.sql.DataSource,name=\"jdbc/my-datasource\"";
+        String actual = strategy.getResultName(query, new ObjectName(objectName), null, "count");
+        assertThat(actual, is("Catalina.javax.sql.DataSource.localhost.jdbc_my-datasource.Context.Resource.count"));
+    }
+}

--- a/src/test/java/org/jmxtrans/agent/JConsoleNameStrategyImplTest.java
+++ b/src/test/java/org/jmxtrans/agent/JConsoleNameStrategyImplTest.java
@@ -35,12 +35,17 @@ import static org.junit.Assert.assertThat;
  * @author <a href="mailto:maheshkelkar@gmail.com">Mahesh V Kelkar</a>
  */
 public class JConsoleNameStrategyImplTest {
-
     static JConsoleNameStrategyImpl strategy = new JConsoleNameStrategyImpl();
-    static Query query = new Query("*:*", "count", strategy); /* dummy */
+    static ExpressionLanguageEngineImpl expressionLanguageEngine = new ExpressionLanguageEngineImpl();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        strategy.setExpressionLanguageEngine(expressionLanguageEngine);
+    }
 
     @Test
     public void testGetResultName() throws Exception {
+        Query query = new Query("*:*", "count", null, strategy);
         String objectName = "Catalina:type=Resource,resourcetype=Context,host=localhost,class=javax.sql.DataSource,name=\"jdbc/my-datasource\"";
         String actual = strategy.getResultName(query, new ObjectName(objectName), "usage", "count");
         assertThat(actual, is("Catalina.javax.sql.DataSource.localhost.jdbc_my-datasource.Context.Resource.count.usage"));
@@ -48,6 +53,7 @@ public class JConsoleNameStrategyImplTest {
 
     @Test
     public void testGetResultNameWithObjectName() throws Exception {
+        Query query = new Query("*:*", "count", null, strategy);
         String objectName = "Catalina:type=Resource,resourcetype=Context,host=localhost,class=javax.sql.DataSource,name=\"jdbc/my-datasource\"";
         String actual = strategy.getResultName(query, new ObjectName(objectName), null, null);
         assertThat(actual, is("Catalina.javax.sql.DataSource.localhost.jdbc_my-datasource.Context.Resource"));
@@ -55,6 +61,7 @@ public class JConsoleNameStrategyImplTest {
 
     @Test
     public void testGetResultNameWithNullAttributeName() throws Exception {
+        Query query = new Query("*:*", "count", null, strategy);
         String objectName = "Catalina:type=Resource,resourcetype=Context,host=localhost,class=javax.sql.DataSource,name=\"jdbc/my-datasource\"";
         String actual = strategy.getResultName(query, new ObjectName(objectName), "usage", null);
         assertThat(actual, is("Catalina.javax.sql.DataSource.localhost.jdbc_my-datasource.Context.Resource.usage"));
@@ -62,8 +69,17 @@ public class JConsoleNameStrategyImplTest {
 
     @Test
     public void testGetResultNameWithNullKeyName() throws Exception {
+        Query query = new Query("*:*", "count", null, strategy);
         String objectName = "Catalina:type=Resource,resourcetype=Context,host=localhost,class=javax.sql.DataSource,name=\"jdbc/my-datasource\"";
         String actual = strategy.getResultName(query, new ObjectName(objectName), null, "count");
         assertThat(actual, is("Catalina.javax.sql.DataSource.localhost.jdbc_my-datasource.Context.Resource.count"));
+    }
+
+    @Test
+    public void testGetResultNameWithResultAlias() throws Exception {
+        Query query = new Query("Catalina:*", "count", "Katalina:%name%.%type%", strategy);
+        String objectName = "Catalina:type=Resource,resourcetype=Context,host=localhost,class=javax.sql.DataSource,name=\"jdbc/my-datasource\"";
+        String actual = strategy.getResultName(query, new ObjectName(objectName), "usage", "count");
+        assertThat(actual, is("Katalina:jdbc_my-datasource.Resource"));
     }
 }

--- a/src/test/java/org/jmxtrans/agent/QueryTest.java
+++ b/src/test/java/org/jmxtrans/agent/QueryTest.java
@@ -47,6 +47,7 @@ public class QueryTest {
     static Mock mock = new Mock("PS Eden Space", 87359488L);
     MockOutputWriter mockOutputWriter = new MockOutputWriter();
     ResultNameStrategy resultNameStrategy = new ResultNameStrategyImpl();
+    ResultNameStrategy jConsoleNameStrategy = new JConsoleNameStrategyImpl();
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -83,6 +84,15 @@ public class QueryTest {
         Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", null, resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         Object actual = mockOutputWriter.resultsByName.get("test.name__mock.type__Mock.CollectionUsageThreshold");
+        assertThat(actual, notNullValue());
+        assertThat(actual, instanceOf(Number.class));
+    }
+
+    @Test
+    public void attribute_with_jconsole_name_strategy_format() throws Exception {
+        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", jConsoleNameStrategy);
+        query.collectAndExport(mbeanServer, mockOutputWriter);
+        Object actual = mockOutputWriter.resultsByName.get("test.mock.Mock.CollectionUsageThreshold");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
@@ -178,7 +188,7 @@ public class QueryTest {
 
     @Test
     public void query_wildcard_objectname_property_returns_mbean_with_resultalias() throws Exception {
-        Query query = new Query("test:*", "CollectionUsageThreshold", "altTest.%name%.%type%", resultNameStrategy);
+             Query query = new Query("test:*", "CollectionUsageThreshold", "altTest.%name%.%type%", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         Object actual = mockOutputWriter.resultsByName.get("altTest.mock.Mock");
         assertThat(actual, notNullValue());

--- a/src/test/java/org/jmxtrans/agent/QueryTest.java
+++ b/src/test/java/org/jmxtrans/agent/QueryTest.java
@@ -45,14 +45,17 @@ public class QueryTest {
     static MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
     static ObjectName mockObjectName;
     static Mock mock = new Mock("PS Eden Space", 87359488L);
-    MockOutputWriter mockOutputWriter = new MockOutputWriter();
-    ResultNameStrategy resultNameStrategy = new ResultNameStrategyImpl();
-    ResultNameStrategy jConsoleNameStrategy = new JConsoleNameStrategyImpl();
+    static MockOutputWriter mockOutputWriter = new MockOutputWriter();
+    static ResultNameStrategyImpl resultNameStrategy = new ResultNameStrategyImpl();
+    static JConsoleNameStrategyImpl jConsoleNameStrategy = new JConsoleNameStrategyImpl();
+    static ExpressionLanguageEngineImpl expressionLanguageEngine = new ExpressionLanguageEngineImpl();
 
     @BeforeClass
     public static void beforeClass() throws Exception {
         mockObjectName = new ObjectName("test:type=Mock,name=mock");
         mbeanServer.registerMBean(mock, mockObjectName);
+        resultNameStrategy.setExpressionLanguageEngine(expressionLanguageEngine);
+        jConsoleNameStrategy.setExpressionLanguageEngine(expressionLanguageEngine);
     }
 
     @AfterClass
@@ -90,7 +93,7 @@ public class QueryTest {
 
     @Test
     public void attribute_with_jconsole_name_strategy_format() throws Exception {
-        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", jConsoleNameStrategy);
+        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", null, jConsoleNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         Object actual = mockOutputWriter.resultsByName.get("test.mock.Mock.CollectionUsageThreshold");
         assertThat(actual, notNullValue());


### PR DESCRIPTION
Adding such strings make the resultName self-explanatory, especially when wildcarding the objectName or attributes.

Fixes #39

Sponsored by: Lookout, Inc.
